### PR TITLE
Update dependencies of ruby-lumberjack to 0.0.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2 @@
+# 1.0.1
+- Force dependencies of `ruby-lumberjack` to **0.0.23**, This version make sure the Client verify the server certificate.

--- a/logstash-output-lumberjack.gemspec
+++ b/logstash-output-lumberjack.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-lumberjack'
-  s.version         = '1.0.0'
+  s.version         = '1.0.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Send events using the lumberjack protocol"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   # Gem dependencies
   s.add_runtime_dependency "logstash-core", '>= 1.4.0', '< 2.0.0'
 
-  s.add_runtime_dependency 'jls-lumberjack', ['>=0.0.20']
+  s.add_runtime_dependency 'jls-lumberjack', ['>=0.0.23']
 
   s.add_development_dependency 'logstash-devutils'
 end


### PR DESCRIPTION
This version of the library make sure the client is correctly verifying
the certificate of the server.
