### PR TITLE
 Fix drop events between two logstash instances

### DIFF
--- a/lib/logstash/outputs/lumberjack.rb
+++ b/lib/logstash/outputs/lumberjack.rb
@@ -13,7 +13,7 @@ class LogStash::Outputs::Lumberjack < LogStash::Outputs::Base
   config :ssl_certificate, :validate => :path, :required => true
 
   # window size
-  config :window_size, :validate => :number, :default => 5000
+  config :window_size, :validate => :number, :default => 1024
 
   public
   def register

--- a/lib/logstash/outputs/lumberjack.rb
+++ b/lib/logstash/outputs/lumberjack.rb
@@ -18,7 +18,7 @@ class LogStash::Outputs::Lumberjack < LogStash::Outputs::Base
   config :ssl_certificate, :validate => :path, :required => true
 
   # window size
-  config :window_size, :validate => :number, :default => 1024, :deprecated => "Use `flush_size`"
+  config :window_size, :validate => :number, :deprecated => "Use `flush_size`", :require => false
   
   # To make efficient calls to the lumberjack output we are buffering events locally. 
   # if the number of events exceed the number the declared `flush_size` we will 

--- a/logstash-output-lumberjack.gemspec
+++ b/logstash-output-lumberjack.gemspec
@@ -29,7 +29,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency "logstash-output-lumberjack"
   s.add_development_dependency "logstash-codec-plain"
-  s.add_development_dependency "stud"
   s.add_development_dependency "flores"
 end
 

--- a/logstash-output-lumberjack.gemspec
+++ b/logstash-output-lumberjack.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   # Gem dependencies
   s.add_runtime_dependency "logstash-core", '>= 1.4.0', '< 2.0.0'
 
-  s.add_runtime_dependency 'jls-lumberjack', ['>=0.0.23']
+  s.add_runtime_dependency 'jls-lumberjack', ['>=0.0.24']
   s.add_runtime_dependency "stud"
 
   s.add_development_dependency 'logstash-devutils'

--- a/logstash-output-lumberjack.gemspec
+++ b/logstash-output-lumberjack.gemspec
@@ -30,6 +30,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "logstash-output-lumberjack"
   s.add_development_dependency "logstash-codec-plain"
   s.add_development_dependency "stud"
-  s.add_runtime_dependency "flores"
+  s.add_development_dependency "flores"
 end
 

--- a/logstash-output-lumberjack.gemspec
+++ b/logstash-output-lumberjack.gemspec
@@ -24,7 +24,12 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-core", '>= 1.4.0', '< 2.0.0'
 
   s.add_runtime_dependency 'jls-lumberjack', ['>=0.0.23']
+  s.add_runtime_dependency "stud"
 
   s.add_development_dependency 'logstash-devutils'
+  s.add_development_dependency "logstash-output-lumberjack"
+  s.add_development_dependency "logstash-codec-plain"
+  s.add_development_dependency "stud"
+  s.add_runtime_dependency "flores"
 end
 

--- a/spec/outputs/lumberjack_spec.rb
+++ b/spec/outputs/lumberjack_spec.rb
@@ -29,7 +29,7 @@ describe "Sending events" do
       "flush_size" => batch_size
     }
   }
-  let(:input) { LogStash::Outputs::Lumberjack.new(client_options) }
+  let(:output) { LogStash::Outputs::Lumberjack.new(client_options) }
 
   context "when the server closes the connection" do
     before do
@@ -56,7 +56,7 @@ describe "Sending events" do
         end
       end
 
-      input.register
+      output.register
     end
 
     after do
@@ -67,9 +67,7 @@ describe "Sending events" do
     it "reconnects and resend the payload" do
       # We guarantee at least once, 
       # duplicates can happen in this scenario.
-      batch_payload.each do |event|
-        input.receive(event)
-      end
+      batch_payload.each { |event| output.receive(event) }
 
       try(10) { expect(queue.size).to be >= batch_size }
       expect(queue.map { |e| e["line"] }).to include(*batch_payload.map(&:to_s))

--- a/spec/outputs/lumberjack_spec.rb
+++ b/spec/outputs/lumberjack_spec.rb
@@ -1,1 +1,89 @@
+# encoding: utf-8
+require "logstash/outputs/Lumberjack"
+require "logstash/event"
 require "logstash/devutils/rspec/spec_helper"
+require "lumberjack/server"
+require "flores/pki"
+require "stud/temporary"
+require "fileutils"
+
+describe "Sending events" do
+  let(:batch_size) { Flores::Random.integer(20..100) }
+  let(:batch_payload) do
+    batch = []
+    batch_size.times do |n|
+      batch << LogStash::Event.new({ "message" => "foobar #{n}" })
+    end
+    batch
+  end
+
+  let(:number_of_crash) { Flores::Random.integer(1..3) }
+  let(:certificate) { Flores::PKI.generate }
+  let(:certificate_file_crt) { Stud::Temporary.pathname }
+  let(:certificate_file_key) { Stud::Temporary.pathname }
+  let(:port) { Flores::Random.integer(1024..65535) }
+  let(:host) { "127.0.0.1" }
+  let(:queue) { [] }
+
+  let(:client_options) {
+    {
+      "hosts" => [host],
+      "port" => port,
+      "ssl_certificate" => certificate_file_crt,
+      "flush_size" => 10#batch_size # flush at the end of the payload
+    }
+  }
+  let(:input) { LogStash::Outputs::Lumberjack.new(client_options) }
+
+  context "when the server closes the connection" do
+    before do
+      File.open(certificate_file_crt, "a") { |f| f.write(certificate.first) }
+      File.open(certificate_file_key, "a") { |f| f.write(certificate.last) }
+
+      server = Lumberjack::Server.new(:port => port,
+                                      :address => host,
+                                      :ssl_certificate => certificate_file_crt,
+                                      :ssl_key => certificate_file_key)
+
+      crashed_count = 0
+      @server = Thread.new do
+        begin
+          server.run do |data|
+            crashed_count += 1
+
+            # make the client crash, forcing a retransmit.
+            # send his payload.
+            if crashed_count < number_of_crash && Random.rand >= 0.5
+              crashed_count += 1
+              raise "crashed"
+            end
+
+            queue << data
+          end
+        rescue
+          puts "CRASHED ONCEEEEE"
+        end
+      end
+
+      input.register
+    end
+
+    after do
+      FileUtils.rm_rf(certificate_file_crt)
+      FileUtils.rm_rf(certificate_file_key)
+    end
+
+    it "reconnects and resend the payload" do
+      # We guarantee at least once, 
+      # duplicates can happen in this scenario.
+      batch_payload.each do |event|
+        input.receive(event)
+      end
+
+      sleep(3) # backoff a bit, mocking the socket would fix this kind of issues?
+
+      expect(queue.size).to be >= batch_size
+      expect(queue.map { |e| e["line"] }).to include(*batch_payload.map(&:to_s))
+    end
+  end
+end


### PR DESCRIPTION
This PR introduce the `bulk` send feature of the ruby client and add a
local buffer inside this plugin. Theses changes make the plugin closer
to the LSF behavior.
