### PR TITLE
Flush the events when Logstash is shutting down

### DIFF
--- a/lib/logstash/outputs/lumberjack.rb
+++ b/lib/logstash/outputs/lumberjack.rb
@@ -1,5 +1,6 @@
 # encoding: utf-8
 require "logstash/outputs/base"
+require "logstash/errors"
 require "stud/buffer"
 require "thread"
 
@@ -57,7 +58,6 @@ class LogStash::Outputs::Lumberjack < LogStash::Outputs::Base
 
   public
   def receive(event)
-    
     return if event == LogStash::SHUTDOWN
     @codec.encode(event)
   end # def receive
@@ -72,6 +72,10 @@ class LogStash::Outputs::Lumberjack < LogStash::Outputs::Base
       connect
       retry
     end # begin
+  end
+
+  def close
+    buffer_flush(:force => true) 
   end
   
   private 

--- a/lib/logstash/outputs/lumberjack.rb
+++ b/lib/logstash/outputs/lumberjack.rb
@@ -20,9 +20,9 @@ class LogStash::Outputs::Lumberjack < LogStash::Outputs::Base
 
   # window size
   config :window_size, :validate => :number, :deprecated => "Use `flush_size`", :require => false
-  
-  # To make efficient calls to the lumberjack output we are buffering events locally. 
-  # if the number of events exceed the number the declared `flush_size` we will 
+
+  # To make efficient calls to the lumberjack output we are buffering events locally.
+  # if the number of events exceed the number the declared `flush_size` we will
   # send them to the logstash server.
   config :flush_size, :validate => :number, :default => 1024
 
@@ -75,25 +75,25 @@ class LogStash::Outputs::Lumberjack < LogStash::Outputs::Base
   end
 
   def close
-    buffer_flush(:force => true) 
+    buffer_flush(:force => true)
   end
-  
-  private 
+
+  private
   def max_items
     @window_size || @flush_size
   end
 
   def connect
     require 'resolv'
-    @logger.info("Connecting to lumberjack server.", :addresses => @hosts, :port => @port, 
+    @logger.info("Connecting to lumberjack server.", :addresses => @hosts, :port => @port,
         :ssl_certificate => @ssl_certificate, :window_size => @window_size)
     begin
       ips = []
       @hosts.each { |host| ips += Resolv.getaddresses host }
-      @client = Lumberjack::Client.new(:addresses => ips.uniq, :port => @port, 
+      @client = Lumberjack::Client.new(:addresses => ips.uniq, :port => @port,
         :ssl_certificate => @ssl_certificate, :window_size => @window_size)
     rescue Exception => e
-      @logger.error("All hosts unavailable, sleeping", :hosts => ips.uniq, :e => e, 
+      @logger.error("All hosts unavailable, sleeping", :hosts => ips.uniq, :e => e,
         :backtrace => e.backtrace)
       sleep(10)
       retry

--- a/logstash-output-lumberjack.gemspec
+++ b/logstash-output-lumberjack.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-lumberjack'
-  s.version         = '2.0.1'
+  s.version         = '2.0.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Send events using the lumberjack protocol"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
This plugin has a memory buffer, because it send the events in batch
to the lumberjack server, we need to make sure we are flushing the
events when we are closing the pipeline

Fixes #12
