### PR TITLE
Remove of unusefull SHUTDOWN event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.8
+  - Fix: dropped usage of SHUTDOWN event deprecated since Logstash 5.0 [#31](https://github.com/logstash-plugins/logstash-output-lumberjack/pull/31)
+
 ## 3.1.7
   - Docs: Set the default_codec doc attribute.
 

--- a/lib/logstash/outputs/lumberjack.rb
+++ b/lib/logstash/outputs/lumberjack.rb
@@ -55,7 +55,6 @@ class LogStash::Outputs::Lumberjack < LogStash::Outputs::Base
 
   public
   def receive(event)
-    return if event == LogStash::SHUTDOWN
     @codec.encode(event)
   end # def receive
 

--- a/logstash-output-lumberjack.gemspec
+++ b/logstash-output-lumberjack.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-lumberjack'
-  s.version         = '3.1.7'
+  s.version         = '3.1.8'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Sends events using the `lumberjack` protocol"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/outputs/lumberjack_spec.rb
+++ b/spec/outputs/lumberjack_spec.rb
@@ -1,8 +1,8 @@
 # encoding: utf-8
+require "logstash/devutils/rspec/spec_helper"
 require "logstash/outputs/lumberjack"
 require "logstash/errors"
 require "logstash/event"
-require "logstash/devutils/rspec/spec_helper"
 require "lumberjack/server"
 require "flores/pki"
 require "stud/temporary"


### PR DESCRIPTION
In Logstash 8.0 the SHUTDOWN event is removed and was deprecated/not used since Logstash 5.0, remove it.

