### PR TITLE
Connect to upstream hosts in random order

### DIFF
--- a/lib/logstash/outputs/lumberjack.rb
+++ b/lib/logstash/outputs/lumberjack.rb
@@ -81,7 +81,7 @@ class LogStash::Outputs::Lumberjack < LogStash::Outputs::Base
         :ssl_certificate => @ssl_certificate, :flush_size => @flush_size)
     begin
       ips = []
-      @hosts.each { |host| ips += Resolv.getaddresses host }
+      @hosts.shuffle.each { |host| ips += Resolv.getaddresses host }
       @client = Lumberjack::Client.new(:addresses => ips.uniq, :port => @port,
         :ssl_certificate => @ssl_certificate, :flush_size => @flush_size)
     rescue Exception => e


### PR DESCRIPTION
At present lumberjack always connect to the listed hosts in order specified in the configuration.  This is bad for load balancing reasons, as the first host will always get the majority or the work, leaving subsequent nodes idle.

Bu shuffling the host list before connecting, we connect to them in a random order each time, spreading the load in a more even way.